### PR TITLE
Pojection functions

### DIFF
--- a/pykeeb/keyboard_arc.py
+++ b/pykeeb/keyboard_arc.py
@@ -1,7 +1,7 @@
 from openpyscad import *
 from .pykeeb import *
 from .keyswitch_mount import *
-test
+
 class Keyboard_arc:
 	def __init__(self, columns, neg_columns, rows, arc_length, arc_angle, z_arc_length=0, z_arc_angle=0, row_spacing=2, column_spacing=2, plate_thickness=3, origin=[0,0,0], x_tent=0, y_tent=0, z_tent=0, mount_length=DSA_KEY_WIDTH, mount_width=DSA_KEY_WIDTH):
 		"""Builds an arc of keyswitch mounts, curvature defined by arc_length, with arc_angle degrees between each mount.  neg_columns allows for mounts to be created on both sides of the origin.  Can also curve in against it's own normal dimension using z_arc_length and z_arc_angle, allowing for some nice sloped key arcs for the thumbs.  Otherwise the same as Keyboard_matrix().  ***NOTE:  Only tested with one row despite accepting multiple rows.***"""

--- a/pykeeb/keyboard_arc.py
+++ b/pykeeb/keyboard_arc.py
@@ -1,7 +1,7 @@
 from openpyscad import *
 from .pykeeb import *
 from .keyswitch_mount import *
-
+test
 class Keyboard_arc:
 	def __init__(self, columns, neg_columns, rows, arc_length, arc_angle, z_arc_length=0, z_arc_angle=0, row_spacing=2, column_spacing=2, plate_thickness=3, origin=[0,0,0], x_tent=0, y_tent=0, z_tent=0, mount_length=DSA_KEY_WIDTH, mount_width=DSA_KEY_WIDTH):
 		"""Builds an arc of keyswitch mounts, curvature defined by arc_length, with arc_angle degrees between each mount.  neg_columns allows for mounts to be created on both sides of the origin.  Can also curve in against it's own normal dimension using z_arc_length and z_arc_angle, allowing for some nice sloped key arcs for the thumbs.  Otherwise the same as Keyboard_matrix().  ***NOTE:  Only tested with one row despite accepting multiple rows.***"""

--- a/pykeeb/keyboard_matrix.py
+++ b/pykeeb/keyboard_matrix.py
@@ -38,6 +38,9 @@ class Keyboard_matrix:
 
 
 	def project_rows(self, R):
+		"""This function 2-dimensionally projects the keyboard rows onto a circle on the y and z axes with radius R."""
+
+		#TODO: Make the focus of the circle adjustable
 
 		unit_width=(self.row_spacing+self.mount_width)
 		unitangle=degrees(2*asin(unit_width/(2*R)))
@@ -57,6 +60,9 @@ class Keyboard_matrix:
 		    self.rm[row]= [0, xt, zt, theta, 0, 0]
 
 	def project_cols(self, R):
+		"""This function 2-dimensionally projects the keyboard columns onto a circle  with radius R on the y-z axes."""
+
+		#TODO: Make the focus of the circle adjustable
 
 		unit_width=(self.column_spacing+self.mount_width)
 		unitangle=degrees(2*asin(unit_width/(2*R)))
@@ -154,6 +160,7 @@ class Keyboard_matrix:
 		return x
 
 	def get_plate(self): #needs more elegant solution, maybe using __add__?
+	    """"Returns the union of the keyswitch mounts and their connecting hulls to form a plate"""
 			x = Cube(0) 
 			for column in range(self.columns):
 				for row in range(self.rows):
@@ -168,6 +175,7 @@ class Keyboard_matrix:
 
 
 	def get_walls(self): #needs more elegant solution, maybe using __add__?
+         """Reterns the union of all the keyboard side walls and their connecting hulls to form a case"""
 			x = Cube(0) 
 			for column in range(self.columns):
 				for row in range(self.rows):
@@ -195,10 +203,4 @@ class Keyboard_matrix:
 						x += self.right_wall[row]
 						if row < self.rows - 1:
 							x += self.right_wall_hulls[row]
-					# if row < self.rows - 1:
-					# 	x += self.row_hulls[row][column]
-					# 	if column < self.columns - 1:
-					# 		x += self.corner_hulls[row][column]
-					# if column < self.columns - 1:
-					# 	x += self.column_hulls[row][column]
 			return x

--- a/pykeeb/keyboard_matrix.py
+++ b/pykeeb/keyboard_matrix.py
@@ -39,14 +39,15 @@ class Keyboard_matrix:
 		"""project the rows onto a circular arc with radius R. Origin of the circle is calculated
 		   to be in the center of the keyboard 1 radius length above it."""
 
+		#maintain key spacing to prevent keycap clashing
 		unit_width=(self.row_spacing+self.mount_width)
 		unitangle=degrees(2*asin(unit_width/(2*R)))
 
-
+		#focus of the sphere
 		focus_x= self.origin[0]+((self.rows/2)*unit_width)
 		focus_z=self.origin[2]+R
 
-		
+		#loop through the rows and calculate the projected coordinates of each
 		for row in range(self.rows):
 		    x=row*unit_width
 
@@ -60,15 +61,16 @@ class Keyboard_matrix:
 	def project_cols(self, R):
 		"""project the columns onto a circular arc with radius R. Origin of the circle is calculated
 		   to be in the center of the keyboard 1 radius length above it."""
-
+		
+		#maintain key spacing to prevent keycap clashing
 		unit_width=(self.column_spacing+self.mount_width)
 		unitangle=degrees(2*asin(unit_width/(2*R)))
 
-
+		#focus of the sphere
 		focus_y= self.origin[0]+((self.columns/2)*unit_width)
 		focus_z=self.origin[2]+R
 
-		
+		#loop through the columns and calculate the projected coordinates of each
 		for col in range(self.columns):
 		    y=col*unit_width
 

--- a/pykeeb/keyboard_matrix.py
+++ b/pykeeb/keyboard_matrix.py
@@ -34,7 +34,51 @@ class Keyboard_matrix:
 		self.im = self.indiv_modifiers = [[[0, 0, 0, 0, 0, 0] for a in range(c)] for b in range(r)] 
 		self.ik = self.ignore_keys = [[False for a in range(c)] for b in range(r)] 
 		self.generate()
+		
+	def project_rows(self, R):
+		"""project the rows onto a circular arc with radius R. Origin of the circle is calculated
+		   to be in the center of the keyboard 1 radius length above it."""
 
+		unit_width=(self.row_spacing+self.mount_width)
+		unitangle=degrees(2*asin(unit_width/(2*R)))
+
+
+		focus_x= self.origin[0]+((self.rows/2)*unit_width)
+		focus_z=self.origin[2]+R
+
+		
+		for row in range(self.rows):
+		    x=row*unit_width
+
+		    theta=-(((self.rows-1)/2)-row)*unitangle
+
+		    zt=focus_z-((cos(radians(theta))*R))
+		    xt=(focus_x+(sin(radians(theta))*(R+7)))-x
+		    self.rm[row]= [0, xt, zt, theta, 0, 0]
+
+			
+	def project_cols(self, R):
+		"""project the columns onto a circular arc with radius R. Origin of the circle is calculated
+		   to be in the center of the keyboard 1 radius length above it."""
+
+		unit_width=(self.column_spacing+self.mount_width)
+		unitangle=degrees(2*asin(unit_width/(2*R)))
+
+
+		focus_y= self.origin[0]+((self.columns/2)*unit_width)
+		focus_z=self.origin[2]+R
+
+		
+		for col in range(self.columns):
+		    y=col*unit_width
+
+		    theta=-(((self.columns-1)/2)-col)*unitangle
+
+		    zt=focus_z-((cos(radians(theta))*R))
+		    yt=(focus_y+(sin(radians(theta))*(R+7)))-y
+		    self.cm[col]= [yt, 0, zt, 0, -theta, 0]
+
+			
 	def generate(self):	
 		"""Generates the matrix w.r.t current modifier data.  Needs to be called for any modifier changes to be reflected before calling get_matrix()."""
 

--- a/pykeeb/keyboard_matrix.py
+++ b/pykeeb/keyboard_matrix.py
@@ -38,7 +38,7 @@ class Keyboard_matrix:
 
 
 	def project_rows(self, R):
-		"""This function 2-dimensionally projects the keyboard rows onto a circle with radius R on the y-z axes."""
+		"""This function 2-dimensionally projects the keyboard rows onto a circle with radius R on the x-z axes."""
 
 		#TODO: Make the focus of the circle adjustable
 
@@ -60,7 +60,7 @@ class Keyboard_matrix:
 		    self.rm[row]= [0, xt, zt, theta, 0, 0]
 
 	def project_cols(self, R):
-		"""This function 2-dimensionally projects the keyboard columns onto a circle with radius R on the x-z axes."""
+		"""This function 2-dimensionally projects the keyboard columns onto a circle with radius R on the y-z axes."""
 
 		#TODO: Make the focus of the circle adjustable
 

--- a/pykeeb/keyboard_matrix.py
+++ b/pykeeb/keyboard_matrix.py
@@ -38,7 +38,7 @@ class Keyboard_matrix:
 
 
 	def project_rows(self, R):
-		"""This function 2-dimensionally projects the keyboard rows onto a circle on the y and z axes with radius R."""
+		"""This function 2-dimensionally projects the keyboard rows onto a circle with radius R on the y-z axes."""
 
 		#TODO: Make the focus of the circle adjustable
 
@@ -60,7 +60,7 @@ class Keyboard_matrix:
 		    self.rm[row]= [0, xt, zt, theta, 0, 0]
 
 	def project_cols(self, R):
-		"""This function 2-dimensionally projects the keyboard columns onto a circle  with radius R on the y-z axes."""
+		"""This function 2-dimensionally projects the keyboard columns onto a circle with radius R on the x-z axes."""
 
 		#TODO: Make the focus of the circle adjustable
 

--- a/pykeeb/keyswitch_mount.py
+++ b/pykeeb/keyswitch_mount.py
@@ -7,7 +7,7 @@ class Keyswitch_mount:
 	alps_keyswitch = Import('/usr/models/matias.stl').color('Gray')
 	mx_keyswitch = Import('/usr/models/cherry.stl').color('Gray')
 	dsa_key = Import('/usr/models/dsa_1u.stl').color('White') #18x18x8mm 
-	def __init__(self, transformations, ik=False, switch_type='mx', mount_length=DSA_KEY_WIDTH, mount_width=DSA_KEY_WIDTH):
+	def __init__(self, transformations, ik=False, switch_type='alps', mount_length=DSA_KEY_WIDTH, mount_width=DSA_KEY_WIDTH, mx_notches=True):
 		"""Sets up single switch-mount geometry, with transformations, W.R.T. switch type."""
 		mx_length = 14.4
 		mx_width = 14.4
@@ -16,21 +16,22 @@ class Keyswitch_mount:
 		self.mount_length = mount_length 
 		self.mount_width = mount_width
 		self.switch_type = switch_type
+		
+		
 		mx_hole = Cube([mx_width, mx_length, self.thickness], center=True)
-
-		nipr=((Cylinder(2.75,1,_fn=60).rotate([0,90,90]).translate([-7.2,-1.475,-0.5])))+\
+		nip_r = ((Cylinder(2.75,1,_fn=60).rotate([0,90,90]).translate([-7.2,-1.475,-0.5])))+\
 		     (Cube([1,2.75,3]).rotate([0,-30,0]).translate([-7.2,-1.475,-0.5]))
-
-		nipl=nipr.mirror(-1)
-
-		mx_hole=mx_hole-nipl-nipr
-
+		nip_l = nip_r.mirror(-1)
+		if mx_notches == True:
+			mx_hole = mx_hole - nip_l - nip_r
 
 		alps_hole = Cube([alps_width, alps_length, self.thickness], center=True)
+	
 		if switch_type == 'mx':
 			self.switch_mount = Cube([self.mount_width, self.mount_length, self.thickness], center=True) - mx_hole
 		if switch_type == 'alps':
 			self.switch_mount = Cube([self.mount_width, self.mount_length, self.thickness], center=True) - alps_hole 
+		
 		self.ignore_key = ik
 		self.transformations = transformations
 

--- a/pykeeb/keyswitch_mount.py
+++ b/pykeeb/keyswitch_mount.py
@@ -7,7 +7,7 @@ class Keyswitch_mount:
 	alps_keyswitch = Import('/usr/models/matias.stl').color('Gray')
 	mx_keyswitch = Import('/usr/models/cherry.stl').color('Gray')
 	dsa_key = Import('/usr/models/dsa_1u.stl').color('White') #18x18x8mm 
-	def __init__(self, transformations, ik=False, switch_type='alps', mount_length=DSA_KEY_WIDTH, mount_width=DSA_KEY_WIDTH):
+	def __init__(self, transformations, ik=False, switch_type='mx', mount_length=DSA_KEY_WIDTH, mount_width=DSA_KEY_WIDTH):
 		"""Sets up single switch-mount geometry, with transformations, W.R.T. switch type."""
 		mx_length = 14.4
 		mx_width = 14.4
@@ -17,6 +17,15 @@ class Keyswitch_mount:
 		self.mount_width = mount_width
 		self.switch_type = switch_type
 		mx_hole = Cube([mx_width, mx_length, self.thickness], center=True)
+
+		nipr=((Cylinder(2.75,1,_fn=60).rotate([0,90,90]).translate([-7.2,-1.475,-0.5])))+\
+		     (Cube([1,2.75,3]).rotate([0,-30,0]).translate([-7.2,-1.475,-0.5]))
+
+		nipl=nipr.mirror(-1)
+
+		mx_hole=mx_hole-nipl-nipr
+
+
 		alps_hole = Cube([alps_width, alps_length, self.thickness], center=True)
 		if switch_type == 'mx':
 			self.switch_mount = Cube([self.mount_width, self.mount_length, self.thickness], center=True) - mx_hole


### PR DESCRIPTION
I added two functions to the keyboard_matrix class that allow you to project the initialized row or column positions onto a circular arc. 

Check out my work in progress [replica of the dactyl](https://github.com/ckaros/pythonic_dactyl) keyboard to see how they work. Still need to work out the thumb cluster hulls, but the projection functionality is there.